### PR TITLE
less sketchy drawings, "done right"

### DIFF
--- a/Illustrations/config.mp
+++ b/Illustrations/config.mp
@@ -14,7 +14,7 @@ linecap := butt;
 linejoin := rounded;
 
 % set to 0 to disable the hand-drawn feeling ...
-sketch_amount := 2.25pt;
+sketch_amount := 1.8pt;
 
 pickup bookpen;
 % ... or comment out the line beneath.

--- a/Illustrations/mp-sketch.mp
+++ b/Illustrations/mp-sketch.mp
@@ -48,7 +48,7 @@ fi
 
 %D The variable \type{sketch_amount} determines the amount of randomness in the
 %D drawing
-numeric sketch_amount; sketch_amount := 2bp;
+numeric sketch_amount; sketch_amount := 3bp;
 
 %D The macro \type{sketchdraw} randomized the path before drawing it. The
 %D \type{expr} ... \type{text} trick is copied from the definition of


### PR DESCRIPTION
This rectifies an issue with commit 5028b4acd6dbac72b924bcf7c7004db36c4201fa:

changing the sketchiness value in mp-sketch doesn't do one any good as it'll be then changed in `Illustrations/config.mp`, which is the place for inter-illustration config options.

The diff reverts the change made to `mp-sketch`, and applies it to `config` {1}.

{1} However, config already had it set to 2.25pt (~2.24bp), thus I lowered it to 1.8pt (~1.79bp) instead.
