### PR TITLE
Handle Linux/OSX disagreement regarding find options

### DIFF
--- a/org2tex
+++ b/org2tex
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
-if [ -z $ORG_DIR ]
-then
-ORG_DIR=`find $HOME/.emacs.d/elpa -type d -depth 1 -regex ".*org-[0-9]*"`
+
+set -e
+
+if [[ -z "${ORG_DIR}" ]] && [[ "$(uname)" == "Linux" ]]; then
+    ORG_DIR="$(find $HOME/.emacs.d/elpa -maxdepth 1 -type d -regex ".*org-[0-9]*")"
+elif [[ -z "${ORG_DIR}" ]]; then
+    ORG_DIR="$(find $HOME/.emacs.d/elpa -type d -depth 1 -regex ".*org-[0-9]*")"
 fi
 
-emacs -Q --batch \
-      --eval "(add-to-list 'load-path \"$ORG_DIR\")" \
-      --eval "(require 'org)" \
-      --eval "(setq org-latex-listings 'minted)" \
-      --eval "(setq org-confirm-babel-evaluate nil)" \
-      --visit=$1 --funcall org-latex-export-to-latex
+
+if [[ -d "$ORG_DIR" ]]; then
+    emacs -Q --batch \
+          --eval "(add-to-list 'load-path \"$ORG_DIR\")" \
+          --eval "(require 'org)" \
+          --eval "(setq org-latex-listings 'minted)" \
+          --eval "(setq org-confirm-babel-evaluate nil)" \
+          --visit="$1" --funcall org-latex-export-to-latex
+else
+    echo "No org-mode directory found."
+fi


### PR DESCRIPTION
Linux and OSX (and whatever BSD Apple took their find from) seem to disagree
about the -depth option. All the conditions for a good old fashioned flamewar
are present. Including a passive aggressive comment in the OSX man page about
GNU's misunderstanding of the -d option. org2tex now works on Linux. I tested
on Debian and OSX.

This makes it easier for me to find things to nag you about;) 
