### PR TITLE
Use hyperref to set pdftitle and pdfauthor

### DIFF
--- a/Header.tex
+++ b/Header.tex
@@ -10,7 +10,13 @@
 
 % Colors, links, syntax highlighting
 \usepackage[dvipsnames,table]{xcolor}
-\hypersetup{colorlinks, linkcolor=Sepia, citecolor=Periwinkle}
+\hypersetup{
+    pdftitle={Crypto 101},
+    pdfauthor={Laurens Van Houtven (lvh)},
+    colorlinks,
+    linkcolor=Sepia,
+    citecolor=Periwinkle
+}
 \usepackage{minted}
 \usepackage[acronym,toc]{glossaries}
 \include{Glossary}


### PR DESCRIPTION
For reasons that I do not want to think about orgmode sets the description and
makes sure to credit orgmode as the creator in the pdf metadata but it does not
include the Author or the title. If I was not a lisp weenie I would have set this
in the org file but this works just as well.

Before:

dfc@jumbo:~$ pdfinfo Crypto101.pdf
    Title:
    Subject:    An introduction to cryptography for programmers
    Keywords:
    Author:
    Creator:    Emacs 24.3.1 (Org mode 8.2.6)

After:

```
dfc@jumbo:~$ pdfinfo Crypto101.pdf
Title:      Crypto 101
Subject:    An introduction to cryptography for programmers
Keywords:
Author:     Laurens Van Houtven (lvh)
Creator:    Emacs 24.3.1 (Org mode 8.2.6)
```
