### PR TITLE
Provide backrefs in bibliography as in glossaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.out
 *.pyg
 *.toc
+Crypto101.brf
 # Book, rendered or partially rendered
 Crypto101.tex
 Crypto101.pdf

--- a/Crypto101.bib
+++ b/Crypto101.bib
@@ -15,7 +15,7 @@
 @misc{salsa20:speed,
     author = {D. J. Bernstein},
     title = {Snuffle 2005: the {Salsa20} encryption function},
-    note = {\url{http://cr.yp.to/snuffle.html#speed}},
+    note = {\url{http://cr.yp.to/snuffle.html\#speed}},
 }
 @misc{cryptopp:bench,
     author = {Wei Dai},
@@ -54,7 +54,7 @@
 @misc{cms:padding,
   author = {R. Housley},
   title = {{RFC} 5652: Cryptographic Message Syntax ({CMS})},
-  note = {\url{https://tools.ietf.org/html/rfc5652#section-6.3}},
+  note = {\url{https://tools.ietf.org/html/rfc5652\#section-6.3}},
 }
 @misc{turner:prohibitssl20,
   author = {S. Turner and T. Polk},

--- a/Header.tex
+++ b/Header.tex
@@ -11,7 +11,7 @@
 
 % Colors, links, syntax highlighting
 \usepackage[dvipsnames,table]{xcolor}
-\usepackage{hyperref}
+\usepackage[pagebackref]{hyperref}
 \hypersetup{
     pdftitle={Crypto 101},
     pdfauthor={Laurens Van Houtven (lvh)},


### PR DESCRIPTION
The bibliography entries now provide a page backref just like the
glossary entries. It was supposed to be as simple as passing the
option `pagebackref` to hypreref. For some reason this caused a
problem with two URLs that did not escape the `#` character. Why
this was not a problem before is beyond me. I checked and the
links work--are not escaped--in the resulting pdf. Finally because
there were not enough latex build process artifacts this added a
Crypto.brf file to the build aftermath. Added an entry to gitignore
to ignore the Crypto.brf file.

I hope all is well in the land of the lakenois.
