### PR TITLE
Add red color to Illustrations/CBC/BitFlipping.mp, remove TODO, fix small typo

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -209,7 +209,7 @@ both) is 1:
 \]
 #+END_LATEX
 
-There's a few useful arithmetic tricks we can derive from that.
+There are a few useful arithmetic tricks we can derive from that.
 
 1. You can apply XOR in any order: $a \xor b = b \xor a$, no matter
    what values $a$ and $b$ are.
@@ -1363,9 +1363,6 @@ $X$, the plaintext block $P_{i + 1}$ will also be XORed with $X$. As a
 result, the attacker completely controls that plaintext block
 $P_{i + 1}$, since they can just flip the bits that aren't the value
 they want them to be.
-
-TODO: add previous illustration, but mark the path X takes to
-influence P prime {i + 1} in red or something
 
 This may not sound like a huge deal at first. If you don't know the
 plaintext bytes of that next block, you have no idea which bits to

--- a/Illustrations/CBC/BitFlipping.mp
+++ b/Illustrations/CBC/BitFlipping.mp
@@ -1,6 +1,5 @@
 input ../common;
 
-
 %%% Drawing scale
 numeric u;
 u := 1cm;
@@ -36,7 +35,7 @@ beginfig(1);
     drawarrow (7.5u, 4u) -- (7.5u, 2.25u);
     %  feedback
     drawarrow (3.5u, 2u) -- (4.25u, 2u);
-    drawarrow (4.5u, 5.5u) -- (6u, 5.5u) -- (6u, 2u) -- (7.25u, 2u);
+    drawarrow (4.5u, 5.5u) -- (6u, 5.5u) -- (6u, 2u) -- (7.25u, 2u) withcolor red;
     draw (7.5u, 5.5u) -- (8u, 5.5u);
 
     % labels


### PR DESCRIPTION
This should do what the TODO on page 61 asks for, additionally there happened to be a minor typo I fixed, but forgot and it slipped into the same commit. Not sure if you'd mind that, or if you think the illustration needs a bit more than just recoloring that arrow.