### PR TITLE
Section 9.2: Fix performance comparison and reword the section.

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -2593,12 +2593,13 @@ authentication work is done by secret-key algorithms.
 
 By far the most important reason for this is performance. Compared to our
 speedy stream ciphers (native or otherwise), public-key encryption mechanisms
-are extremely slow. A single 2048-bit RSA encryption takes 0.29 megacycles,
-decryption takes a whopping 11.12 megacycles.  \cite{cryptopp:bench} To put
+are extremely slow. RSA is limited to at most its key size, which for 2048-bit
+means 256 bytes. Under these circumstances encryption takes 0.29 megacycles,
+and decryption takes a whopping 11.12 megacycles.  \cite{cryptopp:bench} To put
 this into perspective, symmetric key algorithms work within an order of
-magnitude of 10 or so cycles per byte in either direction. In order to encrypt
-or decrypt 2048 bytes, that means approximately 20 kilocycles, which is about
-500 times faster than the asymmetric version. The state of the art in secure
+magnitude of 10 or so cycles per byte in either direction. This means it will
+take a symmetric key algorithm approximately 3 kilocycles in order to decrypt
+256 bytes which is about 4000 times faster than the asymmetric version.The state of the art in secure
 symmetric ciphers is even faster: AES-GCM with hardware acceleration or
 Salsa20/ChaCha20 only need about 2 to 4 cycles per byte, further widening the
 performance gap.


### PR DESCRIPTION
The performance comparison assumed a single RSA operation with a
2048-bit key can work on up to 2048 bytes which is incorrect. The limit
is actually lower than 256 bytes which is 2048 *bits*.
Based on that I corrected the math and rephrased the section a bit to be more clear.

I also removed the paragraph at the end about the other problems which
looks incorrect (unless I'm missing something). RSA is limited to 256
bytes the same way AES is limited to its block size. However we can
solve it in the same way we solve it for AES (cipher modes), it's just
that no one has ever bothered (probably because of the performance
issues).