### PR TITLE
Fix definition of block

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -556,7 +556,7 @@ C = E(k, P)
 \end{equation}
 #+END_EXPORT
 
-The plaintext and ciphertext blocks are sequences of bytes. They are
+The plaintext and ciphertext blocks are sequences of bits. They are
 always the same size as one another, and that size is fixed by the
 block cipher: it's called the block cipher's /block size/. The set of
 all possible keys is called the \gls{keyspace}.


### PR DESCRIPTION
In Chapter 6, block is defined as a sequence of _bytes_ in a ciphertext or plaintext. It should be a sequence of _bits_.