### PR TITLE
fix OAEP decryption

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -2809,7 +2809,7 @@ Computing $G(R)$ is a little harder:
 
 #+BEGIN_EXPORT latex
   \[
-  G(R) = H(X) \xor Y
+  G(R) = G(H(X) \xor Y)
   \]
 #+END_EXPORT
 


### PR DESCRIPTION
	modified:   Crypto101.org
According to https://www.wikiwand.com/en/Optimal_asymmetric_encryption_padding ,
R = Y ⊕ H(X), therefore G(R) should be  G(Y ⊕ H(X))