### PR TITLE
Fix size unit of AES S-box

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -753,7 +753,7 @@ produce the remaining columns.
 ***** SubBytes
 
 SubBytes is the S-box (substitution box) in AES. It is $8 \times 8$
-bits in size.
+bytes in size.
 
 It works by taking the multiplicative inverse over the Galois field, and then
 applying an affine transformation so that there are no values $x$ so that $x


### PR DESCRIPTION
This pull request is a mix of question and contribution.

In the AES specification (http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf), page 16, figure 7, the S-box is represented as a matrix of 8x8 bytes, not 8x8 bits.

Is it correct to say that the S-box size is 8x8 bytes, instead of 8x8 bits? 