### PR TITLE
org2tex: use basic regular expression syntax to aid with portability

### DIFF
--- a/org2tex
+++ b/org2tex
@@ -3,7 +3,7 @@
 set -e
 
 if [[ -z "${ORG_DIR}" ]]; then
-    ORG_DIR="$(find -E $HOME/.emacs.d/elpa -maxdepth 1 -type d -regex ".*org(-plus-contrib)?-[0-9]*")"
+    ORG_DIR="$(find $HOME/.emacs.d/elpa -maxdepth 1 -type d -regex '.*org\(-plus-contrib\)*-[0-9]*')"
     # -maxdepth *is* a GNUism, but it's been ported everywhere by now.
 fi
 


### PR DESCRIPTION
This commit changes the regular expression passed to find from extended
to basic syntax. While extended regex syntax is well supported by both
BSD find and GNU find, the options to activate it are different. By just
dropping -E, basic syntax will be used in both platforms.

BSD find, however —or, at least, macOS find— does not include ? as a
metacharacter in basic regular expressions (GNU find does). It does support
{0,1}, but GNU find does not. We solve this by using '*' instead of '?' for
the ‘-plus-contrib’ subgroup, since it really won’t be found more than once.

Closes #338.