### PR TITLE
Remove erroneous double-period

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -161,9 +161,9 @@ particular order):
  - hmmueller, for many, many notes and suggestions
  - postboy (Ivan Zuboff), for many reported issues
  - EdOverflow, for many contributions
- - gliptak (Gábor Lipták) for work on automating builds
+ - gliptak (Gábor Lipták) for work on automating builds,
 
-.. as well as the huge number of people that contributed spelling,
+as well as the huge number of people that contributed spelling,
 grammar and content improvements. Thank you!
 
 * Building blocks


### PR DESCRIPTION
IMHO it reads more easily to have a comma on the preceding bullet point rather than `..`, but this is debatable.

Thanks for such an awesome book, really interesting.