### PR TITLE
Updated line 3287 to reduce confusion

### DIFF
--- a/Crypto101.org
+++ b/Crypto101.org
@@ -3284,7 +3284,7 @@ in a future section.
 It's very easy for the recipient to compute the same function, and verify the
 code is correct. Any change to the message $M_i$ will change the value of $A_i$
 drastically, thanks to the avalanche effect. Unfortunately, it's quite easy for
-attackers to forge messages. Since the authentication codes are usually sent
+attackers to forge messages. Since the MAC is usually sent
 together with the original message, the attacker knows the length of the
 original message. Then, the attacker only has to guess at the length of the
 secret, which is often fixed as part of the protocol, and, even if it isn't, the


### PR DESCRIPTION
When reading this I thought it meant because $S$ and $M_i were hashed together you knew the length of $M_I$, which doesn't any any sense. Although I now understand where I went wrong (I linked, "secret-prefix authentication code" with $S$ in my head), I think a change similar to this would help reduce confusion for newbies like me. 

BUT maybe I'm just being silly and I'm totally misunderstanding.

Alternative: 'attackers to forge messages. Since the MAC is usually sent' => 'attackers to forge messages. Since the $A_i is usually sent'

Side note: First pull request :D