### PR TITLE
Fix failing book build in docker due to git fatal error

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -33,6 +33,8 @@ RUN set -e; \
     done; \
     fc-cache -f -v
 
+RUN git config --system --add safe.directory /repo
+
 RUN useradd -u 1001 runner
 
 # setup texlive to handle having no home directory


### PR DESCRIPTION
When building the book in docker, the build has failed:

```
$ docker run --rm -it -v "$(realpath .)":/repo -u "$(id -u)" crypto101 ./make-lang en latexpdf

make: Entering directory '/repo'
make -C src/ -f Makefile.assets
make[1]: Entering directory '/repo/src'
make[1]: Nothing to be done for 'assets'.
make[1]: Leaving directory '/repo/src'
Running Sphinx v4.3.2
fatal: detected dubious ownership in repository at '/repo'
To add an exception for this directory, call:

	git config --global --add safe.directory /repo

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/config.py", line 329, in eval_config_file
    exec(code, namespace)
  File "/repo/src/conf.py", line 62, in <module>
    version = run_command("git", "rev-parse", "--short", "HEAD")
  File "/repo/src/conf.py", line 59, in run_command
    return subprocess.check_output(args).decode().strip()
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('git', 'rev-parse', '--short', 'HEAD')' returned non-zero exit status 128.

make: *** [Makefile:41: html] Error 2
make: Leaving directory '/repo'
```

**This PR fixes the error.**
(Note: I used `--system` instead of `--global` because there is not /home/runner/ directory in the docker image.)